### PR TITLE
Use RadixSort

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ described in Algorithm 11.8 of the book:
 [Compact Data Structures - A Practical Approach](https://users.dcc.uchile.cl/~gnavarro/CDSbook/),
 Gonzalo Navarro, 2016.
 
+Given a typical text, it runs in $O(n \log n \log \log n)$ time and $O(n)$ additional bits of space,
+where $n$ is the length of the input string and the alphabet size is much smaller than $n$.
+See the book for more details.
+
 ## Documentation
 
 https://docs.rs/small-bwt/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BWT construction in small space
 
+![](https://github.com/kampersanda/small-bwt/actions/workflows/rust.yml/badge.svg)
+[![Documentation](https://docs.rs/small-bwt/badge.svg)](https://docs.rs/small-bwt)
+[![Crates.io](https://img.shields.io/crates/v/small-bwt.svg)](https://crates.io/crates/small-bwt)
+
 This is a Rust implementation of the BWT construction algorithm in small space,
 described in Algorithm 11.8 of the book:
 [Compact Data Structures - A Practical Approach](https://users.dcc.uchile.cl/~gnavarro/CDSbook/),

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -18,7 +18,7 @@ fn criterion_bwt_english(c: &mut Criterion) {
     group.sample_size(SAMPLE_SIZE);
     group.warm_up_time(WARM_UP_TIME);
     group.measurement_time(MEASURE_TIME);
-    group.sampling_mode(SamplingMode::Auto);
+    group.sampling_mode(SamplingMode::Flat);
     let text = english_10mb_txt();
     let mut n = 1000;
     while n <= text.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,27 @@
 //! described in Algorithm 11.8 of the book:
 //! [Compact Data Structures - A Practical Approach](https://users.dcc.uchile.cl/~gnavarro/CDSbook/),
 //! Gonzalo Navarro, 2016.
+//!
+//! [`BwtBuilder`] provides a simple interface to build the BWT.
+//! It inputs a byte slice and outputs the BWT to a write stream.
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use small_bwt::BwtBuilder;
+//!
+//! // The text must end with a smallest terminal character.
+//! let text = "abracadabra$";
+//!
+//! // Build the BWT.
+//! let mut bwt = vec![];
+//! BwtBuilder::new(text.as_bytes())?.build(&mut bwt)?;
+//! let bwt_str = String::from_utf8_lossy(&bwt);
+//! assert_eq!(bwt_str, "ard$rcaaaabb");
+//! ```
+//!
+//! Given a typical text, it runs in `O(n log n loglog n)` time and `O(n)` additional bits of space,
+//! where `n` is the length of the input string and the alphabet size is much smaller than `n`.
+//! See the book for more details.
 #![deny(missing_docs)]
 mod radixsort;
 
@@ -13,7 +34,7 @@ use radixsort::MsdRadixSorter;
 
 /// BWT builder in small space.
 ///
-/// Given a typical text, it runs in `O(n log n log log n)` time and `O(n)` additional bits of space,
+/// Given a typical text, it runs in `O(n log n loglog n)` time and `O(n)` additional bits of space,
 /// where `n` is the length of the input string and the alphabet size is much smaller than `n`.
 /// See the book for more details.
 ///
@@ -67,7 +88,7 @@ impl<'a> BwtBuilder<'a> {
         })
     }
 
-    /// Sets the chunk size.
+    /// Sets the chunk size (for experiments).
     ///
     /// # Arguments
     ///
@@ -80,6 +101,7 @@ impl<'a> BwtBuilder<'a> {
     /// # Errors
     ///
     /// An error is returned if `chunk_size` is zero.
+    #[doc(hidden)]
     pub fn chunk_size(mut self, chunk_size: usize) -> Result<Self> {
         if chunk_size == 0 {
             return Err(anyhow!("chunk_size must be positive."));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,10 @@ use radixsort::MsdRadixSorter;
 
 /// BWT builder in small space.
 ///
+/// Given a typical text, it runs in `O(n log n log log n)` time and `O(n)` additional bits of space,
+/// where `n` is the length of the input string and the alphabet size is much smaller than `n`.
+/// See the book for more details.
+///
 /// # Specifications
 ///
 /// This assumes that the smallest character appears only at the end of the text.
@@ -44,7 +48,7 @@ impl<'a> BwtBuilder<'a> {
     ///
     /// # Arguments
     ///
-    /// * `text` - The text to be transformed.
+    /// * `text` - The text to be transformed, which should satisfy [`verify_terminal_character`].
     ///
     /// # Errors
     ///
@@ -100,12 +104,6 @@ impl<'a> BwtBuilder<'a> {
     }
 
     /// Builds the BWT and writes it to `wrt`.
-    ///
-    /// # Specifications
-    ///
-    /// This assumes that the smallest character appears only at the end of the text.
-    /// Given an unexpected text, the behavior is undefined.
-    /// If you want to verify the text, use [`verify_terminal_character`].
     ///
     /// # Arguments
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! [Compact Data Structures - A Practical Approach](https://users.dcc.uchile.cl/~gnavarro/CDSbook/),
 //! Gonzalo Navarro, 2016.
 #![deny(missing_docs)]
+mod radixsort;
 
 use std::io::Write;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! where `n` is the length of the input string and the alphabet size is much smaller than `n`.
 //! See the book for more details.
 //!
-//! ## Basic Usage
+//! ## Basic usage
 //!
 //! [`BwtBuilder`] provides a simple interface to build the BWT.
 //! It inputs a byte slice and outputs the BWT to a write stream.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,15 @@
+//! # BWT construction in small space
+//!
 //! Implementation of the BWT construction algorithm in small space,
 //! described in Algorithm 11.8 of the book:
 //! [Compact Data Structures - A Practical Approach](https://users.dcc.uchile.cl/~gnavarro/CDSbook/),
 //! Gonzalo Navarro, 2016.
+//!
+//! Given a typical text, it runs in `O(n log n loglog n)` time and `O(n)` additional bits of space,
+//! where `n` is the length of the input string and the alphabet size is much smaller than `n`.
+//! See the book for more details.
+//!
+//! ## Basic Usage
 //!
 //! [`BwtBuilder`] provides a simple interface to build the BWT.
 //! It inputs a byte slice and outputs the BWT to a write stream.
@@ -18,11 +26,9 @@
 //! BwtBuilder::new(text.as_bytes())?.build(&mut bwt)?;
 //! let bwt_str = String::from_utf8_lossy(&bwt);
 //! assert_eq!(bwt_str, "ard$rcaaaabb");
+//! # Ok(())
+//! # }
 //! ```
-//!
-//! Given a typical text, it runs in `O(n log n loglog n)` time and `O(n)` additional bits of space,
-//! where `n` is the length of the input string and the alphabet size is much smaller than `n`.
-//! See the book for more details.
 #![deny(missing_docs)]
 mod radixsort;
 
@@ -46,18 +52,7 @@ use radixsort::MsdRadixSorter;
 ///
 /// # Examples
 ///
-/// ```
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// use small_bwt::BwtBuilder;
-///
-/// let text = "abracadabra$";
-/// let mut bwt = vec![];
-/// BwtBuilder::new(text.as_bytes())?.build(&mut bwt)?;
-/// let bwt_str = String::from_utf8_lossy(&bwt);
-/// assert_eq!(bwt_str, "ard$rcaaaabb");
-/// # Ok(())
-/// # }
-/// ```
+/// See [the top page](crate).
 pub struct BwtBuilder<'a> {
     text: &'a [u8],
     chunk_size: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,10 @@ pub fn verify_terminal_character(text: &[u8]) -> Result<()> {
 /// # }
 /// ```
 pub fn decode_bwt(bwt: &[u8]) -> Result<Vec<u8>> {
+    if bwt.is_empty() {
+        return Err(anyhow!("bwt must not be empty."));
+    }
+
     let counts = {
         let mut counts = vec![0; 256];
         for &c in bwt {
@@ -374,6 +378,9 @@ pub fn decode_bwt(bwt: &[u8]) -> Result<Vec<u8>> {
 
     let mut i = 0;
     while bwt[i] != terminator {
+        if decoded.len() == bwt.len() {
+            return Err(anyhow!("LF mapping will be broken."));
+        }
         decoded.push(bwt[i]);
         i = ranks[bwt[i] as usize] + bwt[..i].iter().filter(|&&c| c == bwt[i]).count();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ use std::io::Write;
 
 use anyhow::{anyhow, Result};
 
+use radixsort::MsdRadixSorter;
+
 /// BWT builder in small space.
 ///
 /// # Specifications
@@ -167,9 +169,8 @@ fn bwt_from_cuts<W: Write>(
         }
 
         progress.print(&format!("Length of the chunks: {:?}", chunks.len()));
+        chunks = MsdRadixSorter::sort(text, chunks, 256);
 
-        // TODO: Use radix sort.
-        chunks.sort_unstable_by(|&a, &b| text[a..].cmp(&text[b..]));
         for &j in &chunks {
             let c = if j == 0 {
                 *text.last().unwrap()

--- a/src/radixsort.rs
+++ b/src/radixsort.rs
@@ -5,6 +5,7 @@ pub struct MsdRadixSorter<'a> {
 }
 
 impl<'a> MsdRadixSorter<'a> {
+    // Assumes that text has a special terminator.
     pub fn sort(text: &'a [u8], suffixes: Vec<usize>, threshold: usize) -> Vec<usize> {
         let n_suffixes = suffixes.len();
         let threshold = threshold.max(1);

--- a/src/radixsort.rs
+++ b/src/radixsort.rs
@@ -6,13 +6,14 @@ pub struct MsdRadixSorter<'a> {
 
 impl<'a> MsdRadixSorter<'a> {
     pub fn sort(text: &'a [u8], suffixes: Vec<usize>, threshold: usize) -> Vec<usize> {
-        let n = suffixes.len();
+        let n_suffixes = suffixes.len();
+        let threshold = threshold.max(1);
         let mut sorter = Self {
             text,
             suffixes,
             threshold,
         };
-        sorter.sort_range(0, n, 0);
+        sorter.sort_range(0, n_suffixes, 0);
         sorter.suffixes
     }
 

--- a/src/radixsort.rs
+++ b/src/radixsort.rs
@@ -25,27 +25,29 @@ impl<'a> MsdRadixSorter<'a> {
             return;
         }
 
-        // Counts occurrences at this level.
-        let mut counts = vec![0; 256];
-        for i in start..end {
-            let c = self.text[self.suffixes[i] + level];
-            counts[c as usize] += 1;
-        }
+        {
+            // Counts occurrences at this level.
+            let mut counts = vec![0; 256];
+            for i in start..end {
+                let c = self.text[self.suffixes[i] + level];
+                counts[c as usize] += 1;
+            }
 
-        // Computes cumulative sums
-        for i in 1..256 {
-            counts[i] += counts[i - 1];
-        }
+            // Computes cumulative sums
+            for i in 1..256 {
+                counts[i] += counts[i - 1];
+            }
 
-        // Bucket sort.
-        let mut sorted = vec![0; end - start];
-        for i in (start..end).rev() {
-            let c = self.text[self.suffixes[i] + level];
-            counts[c as usize] -= 1;
-            sorted[counts[c as usize]] = self.suffixes[i];
-        }
-        for i in start..end {
-            self.suffixes[i] = sorted[i - start];
+            // Bucket sort.
+            let mut sorted = vec![0; end - start];
+            for i in (start..end).rev() {
+                let c = self.text[self.suffixes[i] + level];
+                counts[c as usize] -= 1;
+                sorted[counts[c as usize]] = self.suffixes[i];
+            }
+            for i in start..end {
+                self.suffixes[i] = sorted[i - start];
+            }
         }
 
         // Recursively sort each bucket.

--- a/src/radixsort.rs
+++ b/src/radixsort.rs
@@ -47,9 +47,8 @@ impl<'a> MsdRadixSorter<'a> {
                 counts[c as usize] -= 1;
                 sorted[counts[c as usize]] = self.suffixes[i];
             }
-            for i in start..end {
-                self.suffixes[i] = sorted[i - start];
-            }
+
+            self.suffixes[start..end].copy_from_slice(&sorted[..]);
         }
 
         // Recursively sort each bucket.

--- a/src/radixsort.rs
+++ b/src/radixsort.rs
@@ -1,0 +1,108 @@
+pub struct MsdRadixSorter<'a> {
+    text: &'a [u8],
+    suffixes: Vec<usize>,
+    threshold: usize,
+}
+
+impl<'a> MsdRadixSorter<'a> {
+    pub fn sort(text: &'a [u8], suffixes: Vec<usize>, threshold: usize) -> Vec<usize> {
+        let n = suffixes.len();
+        let mut sorter = Self {
+            text,
+            suffixes,
+            threshold,
+        };
+        sorter.sort_range(0, n, 0);
+        sorter.suffixes
+    }
+
+    fn sort_range(&mut self, start: usize, end: usize, level: usize) {
+        if end - start <= self.threshold {
+            // Sorts small ranges with comparison sort.
+            self.suffixes[start..end].sort_unstable_by(|&a, &b| {
+                self.text[a..].cmp(&self.text[b..]).then_with(|| a.cmp(&b))
+            });
+            return;
+        }
+
+        // Counts occurrences at this level.
+        let mut counts = vec![0; 256];
+        for i in start..end {
+            let c = self.text[self.suffixes[i] + level];
+            counts[c as usize] += 1;
+        }
+
+        // Computes cumulative sums
+        for i in 1..256 {
+            counts[i] += counts[i - 1];
+        }
+
+        // Bucket sort.
+        let mut sorted = vec![0; end - start];
+        for i in (start..end).rev() {
+            let c = self.text[self.suffixes[i] + level];
+            counts[c as usize] -= 1;
+            sorted[counts[c as usize]] = self.suffixes[i];
+        }
+        for i in start..end {
+            self.suffixes[i] = sorted[i - start];
+        }
+
+        // Recursively sort each bucket.
+        let mut i = start;
+        while i < end {
+            let c = self.text[self.suffixes[i] + level];
+            let mut j = i + 1;
+            while j < end && self.text[self.suffixes[j] + level] == c {
+                j += 1;
+            }
+            self.sort_range(i, j, level + 1);
+            i = j;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_msd_radix_sorter_1() {
+        let text = b"abracadabra$";
+        let suffixes = (0..text.len()).collect();
+        let suffixes = MsdRadixSorter::sort(text, suffixes, 1);
+        assert_eq!(suffixes, vec![11, 10, 7, 0, 3, 5, 8, 1, 4, 6, 9, 2]);
+    }
+
+    #[test]
+    fn test_msd_radix_sorter_2() {
+        let text = b"abracadabra$";
+        let suffixes = (0..text.len()).collect();
+        let suffixes = MsdRadixSorter::sort(text, suffixes, 2);
+        assert_eq!(suffixes, vec![11, 10, 7, 0, 3, 5, 8, 1, 4, 6, 9, 2]);
+    }
+
+    #[test]
+    fn test_msd_radix_sorter_4() {
+        let text = b"abracadabra$";
+        let suffixes = (0..text.len()).collect();
+        let suffixes = MsdRadixSorter::sort(text, suffixes, 4);
+        assert_eq!(suffixes, vec![11, 10, 7, 0, 3, 5, 8, 1, 4, 6, 9, 2]);
+    }
+
+    #[test]
+    fn test_msd_radix_sorter_part_1() {
+        let text = b"abracadabra$";
+        let suffixes = vec![1, 3, 4, 7, 10];
+        let suffixes = MsdRadixSorter::sort(text, suffixes, 1);
+        assert_eq!(suffixes, vec![10, 7, 3, 1, 4]);
+    }
+
+    #[test]
+    fn test_msd_radix_sorter_part_2() {
+        let text = b"abracadabra$";
+        let suffixes = vec![1, 3, 4, 7, 10];
+        let suffixes = MsdRadixSorter::sort(text, suffixes, 2);
+        assert_eq!(suffixes, vec![10, 7, 3, 1, 4]);
+    }
+}

--- a/tools/src/bwt.rs
+++ b/tools/src/bwt.rs
@@ -33,7 +33,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
     let text = read_text(&args.input_file, args.teriminator)?;
-    small_bwt::verify_terminal_character(&text)?;
+    small_bwt::verify_terminal_character(&text).map_err(|e| {
+        format!("Got error while verifying terminal character: {e} Consider using -t option.")
+    })?;
 
     let now = Instant::now();
     let builder = BwtBuilder::new(&text)?.verbose(true);

--- a/tools/src/bwt.rs
+++ b/tools/src/bwt.rs
@@ -21,11 +21,7 @@ struct Args {
     #[arg(short = 'o', long, help = "Path to an output bwt file")]
     output_file: Option<String>,
 
-    #[arg(
-        short = 't',
-        long,
-        help = "Flag to add a special terminal character \\0"
-    )]
+    #[arg(short = 't', long, help = "Flag to add a special teriminator \\0")]
     teriminator: bool,
 }
 

--- a/tools/src/bwt.rs
+++ b/tools/src/bwt.rs
@@ -21,9 +21,6 @@ struct Args {
     #[arg(short = 'o', long, help = "Path to an output bwt file")]
     output_file: Option<String>,
 
-    #[arg(short = 'c', long, help = "Optional parameter for chunk size")]
-    chunk_size: Option<usize>,
-
     #[arg(
         short = 't',
         long,
@@ -38,14 +35,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let text = read_text(&args.input_file, args.teriminator)?;
     small_bwt::verify_terminal_character(&text)?;
 
-    let builder = if let Some(chunk_size) = args.chunk_size {
-        BwtBuilder::new(&text)?.chunk_size(chunk_size)?
-    } else {
-        BwtBuilder::new(&text)?
-    };
-    let builder = builder.verbose(true);
-
     let now = Instant::now();
+    let builder = BwtBuilder::new(&text)?.verbose(true);
     if let Some(output_file) = args.output_file.as_ref() {
         let writer = BufWriter::new(File::create(output_file)?);
         builder.build(writer)?;


### PR DESCRIPTION
Good

```
     Running benches/bench.rs (target/release/deps/bench-ff14ae511ee80d71)
Gnuplot not found, using plotters backend
bwt_english/small_bwt/n=1001
                        time:   [126.57 µs 127.11 µs 127.57 µs]
                        change: [-2.1876% -1.8078% -1.3776%] (p = 0.00 < 0.05)
                        Performance has improved.
bwt_english/small_bwt/n=10001
                        time:   [1.4056 ms 1.4138 ms 1.4338 ms]
                        change: [-6.9320% -5.8518% -4.1925%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
bwt_english/small_bwt/n=100001
                        time:   [16.662 ms 16.689 ms 16.726 ms]
                        change: [-9.8045% -9.3616% -8.9951%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking bwt_english/small_bwt/n=1000001: Warming up for 5.0000 s
Warning: Unable to complete 10 samples in 10.0s. You may wish to increase target time to 11.2s or enable flat sampling.
bwt_english/small_bwt/n=1000001
                        time:   [204.09 ms 204.31 ms 204.46 ms]
                        change: [-9.9808% -9.7751% -9.4619%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking bwt_english/small_bwt/n=10000001: Warming up for 5.0000 s
Warning: Unable to complete 10 samples in 10.0s. You may wish to increase target time to 38.0s.
bwt_english/small_bwt/n=10000001
                        time:   [3.7900 s 3.7983 s 3.8065 s]
                        change: [-10.916% -10.404% -9.9016%] (p = 0.00 < 0.05)
                        Performance has improved.
```